### PR TITLE
Add variables and log analytics workspace

### DIFF
--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -33,7 +33,7 @@ module "scepman" {
   # source = "../.." # This is the local path to the module
 
   # Option 2: Use the terraform registry version
-  source  = "glueckkanja-gab/scepman/azurerm"
+  source = "glueckkanja-gab/scepman/azurerm"
   # version = "0.1.0"
 
 
@@ -42,6 +42,7 @@ module "scepman" {
 
   storage_account_name = var.storage_account_name
   key_vault_name       = var.key_vault_name
+  law_name             = var.law_name
 
   service_plan_name                   = var.service_plan_name
   app_service_name_primary            = var.app_service_name_primary

--- a/examples/advanced/terraform.tfvars
+++ b/examples/advanced/terraform.tfvars
@@ -1,9 +1,13 @@
+organization_name    = "my-org"
 location             = "westeurope"
 resource_group_name  = "rg-scepman-dev-025"
 storage_account_name = "stscepmandev025"
 key_vault_name       = "kv-scepman-prod-025"
+law_name             = "law-scepman-prod-025"
+
 
 service_plan_name                   = "plan-scepman-prod-025"
+service_plan_sku                    = "s1"
 app_service_name_primary            = "app-scepman-dev-025"
 app_service_name_certificate_master = "app-scepmancm-dev-025"
 

--- a/examples/advanced/variables.tf
+++ b/examples/advanced/variables.tf
@@ -1,3 +1,9 @@
+variable "organization_name" {
+  type        = string
+  default     = "my-org"
+  description = "Organization name (O=<my-org>)"
+}
+
 variable "location" {
   type        = string
   description = "Azure Region where the resources should be created"
@@ -13,15 +19,68 @@ variable "storage_account_name" {
   description = "Name of the storage account"
 }
 
+variable "law_name" {
+  type        = string
+  description = "Name for the Log Analytics Workspace"
+}
+
+variable "law_workspace_id" {
+  type        = string
+  default     = null
+  description = "Workspace ID of the Log Analytics Workspace"
+}
+
+variable "law_shared_key" {
+  type        = string
+  default     = null
+  description = "Primary or secondary shared key of Log Analytics Workspace"
+}
+
 variable "service_plan_name" {
   type        = string
   description = "Name of the service plan"
+}
+
+variable "service_plan_sku" {
+  type        = string
+  default     = "S1"
+  description = "SKU for App Service Plan"
 }
 
 variable "service_plan_resource_id" {
   type        = string
   default     = null
   description = "Resource ID of the service plan"
+}
+
+variable "app_service_retention_in_days" {
+  type        = number
+  default     = 180
+  description = "How many days http_logs should be kept"
+}
+
+variable "app_service_retention_in_mb" {
+  type        = number
+  default     = 35
+  description = "Max file size of http_logs"
+}
+
+variable "app_service_logs_detailed_error_messages" {
+  type        = bool
+  default     = true
+  description = "Detailed Error messages of the app service"
+}
+
+variable "app_service_logs_failed_request_tracing" {
+  type        = bool
+  default     = false
+  description = "Trace failed requests"
+}
+
+variable "app_service_application_logs_file_system_level" {
+  type        = string
+  default     = "Error"
+  description = "Application Log level for file_system"
 }
 
 variable "app_service_name_primary" {
@@ -45,12 +104,17 @@ variable "tags" {
   description = "A mapping of tags to assign to the resource"
 }
 
-variable "artifacts_repository_url" {
+variable "artifacts_url_primary" {
   type        = string
-  default     = "https://raw.githubusercontent.com/scepman/install/master"
-  description = "URL of the repository containing the artifacts"
+  default     = "https://raw.githubusercontent.com/scepman/install/master/dist/Artifacts.zip"
+  description = "URL of the artifacts for SCEPman"
 }
 
+variable "artifacts_url_certificate_master" {
+  type        = string
+  default     = "https://raw.githubusercontent.com/scepman/install/master/dist-certmaster/CertMaster-Artifacts.zip"
+  description = "URL of the artifacts for SCEPman Certificate Master"
+}
 variable "app_settings_primary" {
   type        = map(string)
   default     = {}

--- a/main.tf
+++ b/main.tf
@@ -158,6 +158,15 @@ resource "azurerm_windows_web_app" "app" {
       condition     = local.app_settings_primary["AppConfig:KeyVaultConfig:RootCertificateConfig:KeyType"] == "RSA" || local.app_settings_primary["AppConfig:KeyVaultConfig:RootCertificateConfig:KeyType"] == "RSA-HSM"
       error_message = "Possible values are 'RSA' or 'RSA-HSM'"
     }
+
+    ignore_changes = [
+      app_settings["AppConfig:AuthConfig:ApplicationId"],
+      app_settings["AppConfig:AuthConfig:ManagedIdentityEnabledForWebsiteHostname"],
+      app_settings["AppConfig:AuthConfig:ManagedIdentityEnabledOnUnixTime"],
+      app_settings["AppConfig:AuthConfig:ManagedIdentityPermissionLevel"],
+      app_settings["AppConfig:CertMaster:URL"],
+      sticky_settings
+    ]
   }
 }
 
@@ -213,6 +222,17 @@ resource "azurerm_windows_web_app" "app_cm" {
         retention_in_mb   = var.app_service_retention_in_mb
       }
     }
+  }
+
+  lifecycle {
+
+    ignore_changes = [
+      app_settings["AppConfig:AuthConfig:ApplicationId"],
+      app_settings["AppConfig:AuthConfig:ManagedIdentityEnabledOnUnixTime"],
+      app_settings["AppConfig:AuthConfig:ManagedIdentityPermissionLevel"],
+      app_settings["AppConfig:AuthConfig:SCEPmanAPIScope"],
+      sticky_settings
+    ]
   }
 
 }

--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,7 @@ locals {
   }
 
   app_settings_primary_base = {
-    "WEBSITE_RUN_FROM_PACKAGE"                          = format("%s/dist/Artifacts.zip", var.artifacts_repository_url)
+    "WEBSITE_RUN_FROM_PACKAGE"                          = var.artifacts_url_primary
     "AppConfig:BaseUrl"                                 = format("https://%s.azurewebsites.net", var.app_service_name_primary)
     "AppConfig:AuthConfig:TenantId"                     = data.azurerm_client_config.current.tenant_id
     "AppConfig:KeyVaultConfig:KeyVaultURL"              = azurerm_key_vault.vault.vault_uri
@@ -149,7 +149,7 @@ locals {
   app_settings_certificate_master_defaults = {}
 
   app_settings_certificate_master_base = {
-    "WEBSITE_RUN_FROM_PACKAGE"                    = format("%s/dist-certmaster/CertMaster-Artifacts.zip", var.artifacts_repository_url)
+    "WEBSITE_RUN_FROM_PACKAGE"                    = var.artifacts_url_certificate_master
     "AppConfig:AzureStorage:TableStorageEndpoint" = azurerm_storage_account.storage.primary_table_endpoint
     "AppConfig:SCEPman:URL"                       = format("https://%s", azurerm_windows_web_app.app.default_hostname)
     "AppConfig:AuthConfig:TenantId"               = data.azurerm_client_config.current.tenant_id

--- a/main.tf
+++ b/main.tf
@@ -120,6 +120,7 @@ resource "azurerm_windows_web_app" "app" {
   name                = var.app_service_name_primary
   resource_group_name = var.resource_group_name
   location            = var.location
+  https_only          = false
 
   service_plan_id = local.service_plan_resource_id
 
@@ -127,11 +128,29 @@ resource "azurerm_windows_web_app" "app" {
     type = "SystemAssigned"
   }
 
-  site_config {}
+  site_config {
+    health_check_path = "/probe"
+  }
 
   app_settings = local.app_settings_primary
 
   tags = var.tags
+
+  logs {
+    detailed_error_messages = var.app_service_logs_detailed_error_messages
+    failed_request_tracing  = var.app_service_logs_failed_request_tracing
+
+    application_logs {
+      file_system_level = var.app_service_application_logs_file_system_level
+    }
+
+    http_logs {
+      file_system {
+        retention_in_days = var.app_service_retention_in_days
+        retention_in_mb   = var.app_service_retention_in_mb
+      }
+    }
+  }
 
   lifecycle {
     # CA Key type must be specific
@@ -172,11 +191,30 @@ resource "azurerm_windows_web_app" "app_cm" {
     type = "SystemAssigned"
   }
 
-  site_config {}
+  site_config {
+    health_check_path = "/probe"
+  }
 
   app_settings = local.app_settings_certificate_master
 
   tags = var.tags
+
+  logs {
+    detailed_error_messages = var.app_service_logs_detailed_error_messages
+    failed_request_tracing  = var.app_service_logs_failed_request_tracing
+
+    application_logs {
+      file_system_level = var.app_service_application_logs_file_system_level
+    }
+
+    http_logs {
+      file_system {
+        retention_in_days = var.app_service_retention_in_days
+        retention_in_mb   = var.app_service_retention_in_mb
+      }
+    }
+  }
+
 }
 
 # Key Vault Access Policy

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "azurerm_service_plan" "plan" {
   location            = var.location
 
   os_type  = "Windows"
-  sku_name = "S1"
+  sku_name = var.service_plan_sku
 
   tags = var.tags
 }
@@ -98,7 +98,7 @@ locals {
     "AppConfig:KeyVaultConfig:RootCertificateConfig:CertificateName" = "SCEPman-Root-CA-V1",
     "AppConfig:KeyVaultConfig:RootCertificateConfig:KeyType"         = "RSA-HSM"
     "AppConfig:ValidityClockSkewMinutes"                             = "1440",
-    "AppConfig:KeyVaultConfig:RootCertificateConfig:Subject"         = format("CN=SCEPman-Root-CA-V1,OU=%s,O=\"my-org\"", data.azurerm_client_config.current.tenant_id)
+    "AppConfig:KeyVaultConfig:RootCertificateConfig:Subject"         = format("CN=SCEPman-Root-CA-V1,OU=%s,O=\"%s\"", data.azurerm_client_config.current.tenant_id, var.organization_name)
   }
 
   app_settings_primary_base = {

--- a/variables.tf
+++ b/variables.tf
@@ -62,12 +62,17 @@ variable "tags" {
   description = "A mapping of tags to assign to the resource"
 }
 
-variable "artifacts_repository_url" {
+variable "artifacts_url_primary" {
   type        = string
-  default     = "https://raw.githubusercontent.com/scepman/install/master"
-  description = "URL of the repository containing the artifacts"
+  default     = "https://raw.githubusercontent.com/scepman/install/master/dist/Artifacts.zip"
+  description = "URL of the artifacts for SCEPman"
 }
 
+variable "artifacts_url_certificate_master" {
+  type        = string
+  default     = "https://raw.githubusercontent.com/scepman/install/master/dist-certmaster/CertMaster-Artifacts.zip"
+  description = "URL of the artifacts for SCEPman Certificate Master"
+}
 variable "app_settings_primary" {
   type        = map(string)
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "organization_name" {
+  type        = string
+  default     = "my-org"
+  description = "Organization name (O=<my-org>)"
+}
+
 variable "location" {
   type        = string
   description = "Azure Region where the resources should be created"
@@ -33,6 +39,12 @@ variable "law_shared_key" {
 variable "service_plan_name" {
   type        = string
   description = "Name of the service plan"
+}
+
+variable "service_plan_sku" {
+  type        = string
+  default     = "S1"
+  description = "SKU for App Service Plan"
 }
 
 variable "service_plan_resource_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,36 @@ variable "service_plan_resource_id" {
   description = "Resource ID of the service plan"
 }
 
+variable "app_service_retention_in_days" {
+  type        = number
+  default     = 180
+  description = "How many days http_logs should be kept"
+}
+
+variable "app_service_retention_in_mb" {
+  type        = number
+  default     = 35
+  description = "Max file size of http_logs"
+}
+
+variable "app_service_logs_detailed_error_messages" {
+  type        = bool
+  default     = true
+  description = "Detailed Error messages of the app service"
+}
+
+variable "app_service_logs_failed_request_tracing" {
+  type        = bool
+  default     = false
+  description = "Trace failed requests"
+}
+
+variable "app_service_application_logs_file_system_level" {
+  type        = string
+  default     = "Error"
+  description = "Application Log level for file_system"
+}
+
 variable "app_service_name_primary" {
   type        = string
   description = "Name of the primary app service"

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,22 @@ variable "storage_account_name" {
   description = "Name of the storage account"
 }
 
+variable "law_name" {
+  type        = string
+  description = "Name for the Log Analytics Workspace"
+}
+
+variable "law_workspace_id" {
+  type        = string
+  default     = null
+  description = "Workspace ID of the Log Analytics Workspace"
+}
+
+variable "law_shared_key" {
+  type        = string
+  default     = null
+  description = "Primary or secondary shared key of Log Analytics Workspace"
+}
 
 variable "service_plan_name" {
   type        = string


### PR DESCRIPTION
Add log analytics workspace which is default since 2.4.
Add variables to set custom or beta/internal artifacts urls.
Add variables for SKU and "Organization" (O= in root cert)
Enable logging and set default settings.
Not allow https_only for SCEPman.
Ignore changes made by the SCEPman install script and sticky settings.
Update example.