### PR TITLE
Fixed link to README for TF Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Visit [containers.dev](https://containers.dev) for more information
 
 ### Advanced
 
-For more informations how to deploy the following example, see [README](examples/advanced/README.md)
+For more informations how to deploy the following example, see the [Advanced Example Documentation](examples/advanced/).
 
 ```hcl
 # Version requirements


### PR DESCRIPTION
The article on TF Registry cannot resolve the README reference. Therefore, the link leads to a 404. It works in both GitHub and TF Registry when the link points to the directory instead of the README.